### PR TITLE
Support for embedded images

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ __underlined__
 @@http://www.github.com@@
 
 [[image.jpg]]
-[[image.jpg:20]]
-[[image.jpg:20vw,20%]]
+[[image.jpg`20]]
+[[image.jpg`20vw,20%]]
 ```
 
 ## Styling
@@ -640,7 +640,7 @@ Four spaces per level.
 
 @@http://www.github.com This is a link@@
 
-@@http://www.github.com [[image.jpg:20]]@@
+@@http://www.github.com [[image.jpg`20]]@@
 
 @@http://www.github.com@@
 
@@ -648,18 +648,18 @@ Four spaces per level.
 
 Small :
 
-[[image.jpg:20]][[image_2.jpg:20]]§
-[[image_3.jpg:20]][[image_4.jpg:20]][[image_5.jpg:20]]
+[[image.jpg`20]][[image_2.jpg`20]]§
+[[image_3.jpg`20]][[image_4.jpg`20]][[image_5.jpg`20]]
 
 Medium :
 
-[[image_3.jpg:40]][[image_4.jpg:40]]
+[[image_3.jpg`40]][[image_4.jpg`40]]
 
 Large :
 
 [[image.jpg]]§
-[[image_2.jpg:]]§
-[[image_4.jpg:,100]]
+[[image_2.jpg`]]§
+[[image_4.jpg`,100]]
 
 Custom :
 
@@ -667,24 +667,24 @@ Custom :
 
 Remote :
 
-[[https://upload.wikimedia.org/wikipedia/commons/b/bb/Ifaty_beach_Madagascar.jpg:40]]
-[[https://upload.wikimedia.org/wikipedia/commons/8/80/Wikipedia-logo-v2.svg:36]]
+[[https://upload.wikimedia.org/wikipedia/commons/b/bb/Ifaty_beach_Madagascar.jpg`40]]
+[[https://upload.wikimedia.org/wikipedia/commons/8/80/Wikipedia-logo-v2.svg`36]]
 
 Effects :
 
-[[^shadow_3\image_6.jpg:20]] [[^shadow_6\image_6.jpg:20]] [[^shadow_9\image_6.jpg:20]] [[^shadow_-6\image_6.jpg:20]]
+[[^shadow_3\image_6.jpg`20]] [[^shadow_6\image_6.jpg`20]] [[^shadow_9\image_6.jpg`20]] [[^shadow_-6\image_6.jpg`20]]
 
-[[^round_10\image_6.jpg:20]] [[^round_20\image_6.jpg:20]] [[^round_50\image_6.jpg:20]] [[^opacity_50\image_6.jpg:20]]
+[[^round_10\image_6.jpg`20]] [[^round_20\image_6.jpg`20]] [[^round_50\image_6.jpg`20]] [[^opacity_50\image_6.jpg`20]]
 
-[[^blur_1\image_6.jpg:20]] [[^lightness_130\image_6.jpg:20]] [[^contrast_180\image_6.jpg:20]] [[^saturation_200\image_6.jpg:20]]
+[[^blur_1\image_6.jpg`20]] [[^lightness_130\image_6.jpg`20]] [[^contrast_180\image_6.jpg`20]] [[^saturation_200\image_6.jpg`20]]
 
-[[^hue_180\image_6.jpg:20]] [[^inverse_100\image_6.jpg:20]] [[^gray_100\image_6.jpg:20]] [[^sepia_100\image_6.jpg:20]]
+[[^hue_180\image_6.jpg`20]] [[^inverse_100\image_6.jpg`20]] [[^gray_100\image_6.jpg`20]] [[^sepia_100\image_6.jpg`20]]
 
 !! Video
 
-[[^&autoplay,&loop,&muted,&controls\video.mp4:20]]
+[[^&autoplay,&loop,&muted,&controls\video.mp4`20]]
 
-[[^&controls,lightness_130\video.mp4:40]]
+[[^&controls,lightness_130\video.mp4`40]]
 
 !! Styling
 

--- a/SAMPLE/sample.html
+++ b/SAMPLE/sample.html
@@ -401,43 +401,43 @@ Four spaces per level.
 
 Small :
 
-[[image.jpg:20]][[image_2.jpg:20]]§
-[[image_3.jpg:20]][[image_4.jpg:20]][[image_5.jpg:20]]
+[[image.jpg`20]][[image_2.jpg`20]]§
+[[image_3.jpg`20]][[image_4.jpg`20]][[image_5.jpg`20]]
 
 Medium :
 
-[[image_3.jpg:40]][[image_4.jpg:40]]
+[[image_3.jpg`40]][[image_4.jpg`40]]
 
 Large :
 
 [[image.jpg]]§
-[[image_2.jpg:]]§
-[[image_4.jpg:,100]]
+[[image_2.jpg`]]§
+[[image_4.jpg`,100]]
 
 Custom :
 
-[[image_5.jpg:50vw,50%]]
+[[image_5.jpg`50vw,50%]]
 
 Remote :
 
-[[https://upload.wikimedia.org/wikipedia/commons/b/bb/Ifaty_beach_Madagascar.jpg:40]]
-[[https://upload.wikimedia.org/wikipedia/commons/8/80/Wikipedia-logo-v2.svg:36]]
+[[https://upload.wikimedia.org/wikipedia/commons/b/bb/Ifaty_beach_Madagascar.jpg`40]]
+[[https://upload.wikimedia.org/wikipedia/commons/8/80/Wikipedia-logo-v2.svg`36]]
 
 Effects :
 
-[[^shadow_3\image_6.jpg:20]] [[^shadow_6\image_6.jpg:20]] [[^shadow_9\image_6.jpg:20]] [[^shadow_-6\image_6.jpg:20]]
+[[^shadow_3\image_6.jpg`20]] [[^shadow_6\image_6.jpg`20]] [[^shadow_9\image_6.jpg`20]] [[^shadow_-6\image_6.jpg`20]]
 
-[[^round_10\image_6.jpg:20]] [[^round_20\image_6.jpg:20]] [[^round_50\image_6.jpg:20]] [[^opacity_50\image_6.jpg:20]]
+[[^round_10\image_6.jpg`20]] [[^round_20\image_6.jpg`20]] [[^round_50\image_6.jpg`20]] [[^opacity_50\image_6.jpg`20]]
 
-[[^blur_1\image_6.jpg:20]] [[^lightness_130\image_6.jpg:20]] [[^contrast_180\image_6.jpg:20]] [[^saturation_200\image_6.jpg:20]]
+[[^blur_1\image_6.jpg`20]] [[^lightness_130\image_6.jpg`20]] [[^contrast_180\image_6.jpg`20]] [[^saturation_200\image_6.jpg`20]]
 
-[[^hue_180\image_6.jpg:20]] [[^inverse_100\image_6.jpg:20]] [[^gray_100\image_6.jpg:20]] [[^sepia_100\image_6.jpg:20]]
+[[^hue_180\image_6.jpg`20]] [[^inverse_100\image_6.jpg`20]] [[^gray_100\image_6.jpg`20]] [[^sepia_100\image_6.jpg`20]]
 
 !! Video
 
-[[^&autoplay,&loop,&muted,&controls\video.mp4:20]]
+[[^&autoplay,&loop,&muted,&controls\video.mp4`20]]
 
-[[^&controls,lightness_130\video.mp4:40]]
+[[^&controls,lightness_130\video.mp4`40]]
 
 !! Styling
 

--- a/SAMPLE/sample_script.html
+++ b/SAMPLE/sample_script.html
@@ -393,7 +393,7 @@ Four spaces per level.
 
 @@http://www.github.com This is a link@@
 
-@@http://www.github.com [[image.jpg:20]]@@
+@@http://www.github.com [[image.jpg`20]]@@
 
 @@http://www.github.com@@
 
@@ -401,43 +401,43 @@ Four spaces per level.
 
 Small :
 
-[[image.jpg:20]][[image_2.jpg:20]]§
-[[image_3.jpg:20]][[image_4.jpg:20]][[image_5.jpg:20]]
+[[image.jpg`20]][[image_2.jpg`20]]§
+[[image_3.jpg`20]][[image_4.jpg`20]][[image_5.jpg`20]]
 
 Medium :
 
-[[image_3.jpg:40]][[image_4.jpg:40]]
+[[image_3.jpg`40]][[image_4.jpg`40]]
 
 Large :
 
 [[image.jpg]]§
-[[image_2.jpg:]]§
-[[image_4.jpg:,100]]
+[[image_2.jpg`]]§
+[[image_4.jpg`,100]]
 
 Custom :
 
-[[image_5.jpg:50vw,50%]]
+[[image_5.jpg`50vw,50%]]
 
 Remote :
 
-[[https://upload.wikimedia.org/wikipedia/commons/b/bb/Ifaty_beach_Madagascar.jpg:40]]
-[[https://upload.wikimedia.org/wikipedia/commons/8/80/Wikipedia-logo-v2.svg:36]]
+[[https://upload.wikimedia.org/wikipedia/commons/b/bb/Ifaty_beach_Madagascar.jpg`40]]
+[[https://upload.wikimedia.org/wikipedia/commons/8/80/Wikipedia-logo-v2.svg`36]]
 
 Effects :
 
-[[^shadow_3\image_6.jpg:20]] [[^shadow_6\image_6.jpg:20]] [[^shadow_9\image_6.jpg:20]] [[^shadow_-6\image_6.jpg:20]]
+[[^shadow_3\image_6.jpg`20]] [[^shadow_6\image_6.jpg`20]] [[^shadow_9\image_6.jpg`20]] [[^shadow_-6\image_6.jpg`20]]
 
-[[^round_10\image_6.jpg:20]] [[^round_20\image_6.jpg:20]] [[^round_50\image_6.jpg:20]] [[^opacity_50\image_6.jpg:20]]
+[[^round_10\image_6.jpg`20]] [[^round_20\image_6.jpg`20]] [[^round_50\image_6.jpg`20]] [[^opacity_50\image_6.jpg`20]]
 
-[[^blur_1\image_6.jpg:20]] [[^lightness_130\image_6.jpg:20]] [[^contrast_180\image_6.jpg:20]] [[^saturation_200\image_6.jpg:20]]
+[[^blur_1\image_6.jpg`20]] [[^lightness_130\image_6.jpg`20]] [[^contrast_180\image_6.jpg`20]] [[^saturation_200\image_6.jpg`20]]
 
-[[^hue_180\image_6.jpg:20]] [[^inverse_100\image_6.jpg:20]] [[^gray_100\image_6.jpg:20]] [[^sepia_100\image_6.jpg:20]]
+[[^hue_180\image_6.jpg`20]] [[^inverse_100\image_6.jpg`20]] [[^gray_100\image_6.jpg`20]] [[^sepia_100\image_6.jpg`20]]
 
 !! Video
 
-[[^&autoplay,&loop,&muted,&controls\video.mp4:20]]
+[[^&autoplay,&loop,&muted,&controls\video.mp4`20]]
 
-[[^&controls,lightness_130\video.mp4:40]]
+[[^&controls,lightness_130\video.mp4`40]]
 
 !! Styling
 

--- a/pendown.d
+++ b/pendown.d
@@ -1153,6 +1153,10 @@ dstring GetFormat(
     {
         return url.slice( dot_character_index + 1 );
     }
+    // Is the image embedded into the document?
+    else if ( url.indexOf( "data:image/" ) > -1 ){
+        return url.slice( url.indexOf( '/' ) + 1, url.indexOf( ";" ) );
+    }
     else
     {
         return "";
@@ -2268,7 +2272,7 @@ TOKEN[] GetTokenArray(
             {
                 size ~= character;
             }
-            else if ( character == ':'
+            else if ( character == '`'
                       && character_index + 1 < text.length
                       && text.charAt( character_index + 1 ) != '/' )
             {

--- a/pendown.js
+++ b/pendown.js
@@ -981,6 +981,10 @@ function GetFormat(
     {
         return url.slice( dot_character_index + 1 );
     }
+    // Is the image embedded into the document?
+    else if ( url.indexOf( "data:image/" ) > -1 ){
+        return url.slice( url.indexOf( '/' ) + 1, url.indexOf( ";" ) )
+    }
     else
     {
         return "";
@@ -2063,7 +2067,7 @@ function GetTokenArray(
             {
                 size += character;
             }
-            else if ( character === ':'
+            else if ( character === '`'
                       && character_index + 1 < text.length
                       && text.charAt( character_index + 1 ) !== '/' )
             {


### PR DESCRIPTION
Hello,

we're looking for a markdown format which does support to put text next to an embedded image.
Since putting text next to an image is already supported by this markdown format,
it lacks the support for embedded images.

With this PR I'm adding support for embedded images.
E.g.
```js
<meta charset="utf8"/>
<link rel="stylesheet" href="pendown.css">

<xmp>
[[data:image/png;base64,iVBORw0KGgoAAAANSUhEUg.......AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKAl/X9CRFg5Tj9OOwAAAABJRU5ErkJggg==`20]]
</xmp>
<script src="pendown.js"></script>
```

To specify the size of the image, i've changed the colon (":") to a backtick ("`").

I've split up the actual implementation and the update of the documentation and
examples in case you would like to update the documentation yourself.

Feedback and code review is welcome and crucial.
Thank you.

Sincely
~